### PR TITLE
Enhance tauri backend

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2759,6 +2759,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs",
+ "open",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6.0"
 chrono = "0.4.41"
+open = "5"


### PR DESCRIPTION
## Summary
- extend `Project` data with Git status and star support
- implement star toggling and open-in-browser handlers
- track starred projects in a config file
- expose new commands for the frontend

## Testing
- `pnpm install`
- `pnpm run build`
- `cargo check` *(fails: gdk-sys missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_686b4166c5c483238166ae6d17e9f45f