### PR TITLE
Add workspace file read/write commands

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppState {
+    pub base_dir: String,
+    pub categories: Vec<String>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        AppState {
+            base_dir: "~/dev".to_string(),
+            categories: vec![
+                "desktop-apps".to_string(),
+                "web-apps".to_string(),
+                "cli-apps".to_string(),
+                "other".to_string(),
+            ],
+        }
+    }
+}

--- a/src-tauri/src/file_ops.rs
+++ b/src-tauri/src/file_ops.rs
@@ -1,0 +1,41 @@
+use std::sync::Mutex;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use tauri::AppHandle;
+
+use crate::app_state::AppState;
+
+fn workspace_path(app: &AppHandle, relative: &str) -> Result<PathBuf, String> {
+    let state = app.state::<Mutex<AppState>>();
+    let base_dir = state
+        .lock()
+        .map_err(|_| "State lock poisoned".to_string())?
+        .base_dir
+        .clone();
+    let base = PathBuf::from(base_dir);
+    let target = base.join(relative);
+
+    let canonical_base =
+        fs::canonicalize(&base).map_err(|e| format!("Failed to resolve base dir: {}", e))?;
+    let canonical_target = fs::canonicalize(&target).unwrap_or(target.clone());
+    if !canonical_target.starts_with(&canonical_base) {
+        return Err("Invalid path".into());
+    }
+    Ok(target)
+}
+
+pub fn read_file(app: &AppHandle, relative: &str) -> Result<String, String> {
+    let path = workspace_path(app, relative)?;
+    fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))
+}
+
+pub fn write_file(app: &AppHandle, relative: &str, contents: &str) -> Result<(), String> {
+    let path = workspace_path(app, relative)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create dirs: {}", e))?;
+    }
+    fs::write(path, contents).map_err(|e| format!("Failed to write file: {}", e))
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,12 +1,16 @@
 // src-tauri/src/main.rs
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
+mod app_state;
+mod file_ops;
 mod workspace;
+
+use app_state::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Project {
@@ -27,26 +31,6 @@ struct ProjectCategory {
     projects: Vec<Project>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct AppState {
-    base_dir: String,
-    categories: Vec<String>,
-}
-
-impl Default for AppState {
-    fn default() -> Self {
-        AppState {
-            base_dir: "~/dev".to_string(),
-            categories: vec![
-                "desktop-apps".to_string(),
-                "web-apps".to_string(),
-                "cli-apps".to_string(),
-                "other".to_string(),
-            ],
-        }
-    }
-}
-
 #[tauri::command]
 fn initialize_workspace(app_handle: tauri::AppHandle) -> Result<String, String> {
     let base = workspace::ensure_workspace(&app_handle)?;
@@ -60,49 +44,51 @@ fn scan_projects(base_dir: String) -> Result<HashMap<String, Vec<Project>>, Stri
 
     let categories = ["desktop-apps", "web-apps", "cli-apps", "other"];
     let starred = load_starred_projects().unwrap_or_default();
-    
+
     for category in categories.iter() {
         let category_path = base_path.join(category);
         let mut projects = Vec::new();
-        
+
         if category_path.exists() && category_path.is_dir() {
             let entries = fs::read_dir(&category_path)
                 .map_err(|e| format!("Failed to read directory {}: {}", category, e))?;
-            
+
             for entry in entries {
                 let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
                 let path = entry.path();
-                
+
                 if path.is_dir() {
                     let project = scan_project_directory(&path, &starred)?;
                     projects.push(project);
                 }
             }
         }
-        
+
         projects_map.insert(category.to_string(), projects);
     }
-    
+
     Ok(projects_map)
 }
 
 fn scan_project_directory(path: &Path, starred_set: &HashSet<String>) -> Result<Project, String> {
-    let name = path.file_name()
+    let name = path
+        .file_name()
         .ok_or("Invalid project directory name")?
         .to_string_lossy()
         .to_string();
-    
-    let metadata = fs::metadata(path)
-        .map_err(|e| format!("Failed to get metadata for {}: {}", name, e))?;
-    
-    let last_modified = metadata.modified()
+
+    let metadata =
+        fs::metadata(path).map_err(|e| format!("Failed to get metadata for {}: {}", name, e))?;
+
+    let last_modified = metadata
+        .modified()
         .map_err(|e| format!("Failed to get modification time: {}", e))?;
-    
+
     let project_type = detect_project_type(path);
     let (size, files_count) = calculate_directory_stats(path)?;
     let git_status = get_git_status(path);
     let starred = starred_set.contains(&path.to_string_lossy().to_string());
-    
+
     Ok(Project {
         name,
         path: path.to_string_lossy().to_string(),
@@ -123,7 +109,7 @@ fn detect_project_type(path: &Path) -> String {
         }
         return "rust".to_string();
     }
-    
+
     if path.join("package.json").exists() {
         let package_json = fs::read_to_string(path.join("package.json")).unwrap_or_default();
         if package_json.contains("\"next\"") {
@@ -137,26 +123,26 @@ fn detect_project_type(path: &Path) -> String {
         }
         return "node".to_string();
     }
-    
+
     if path.join("go.mod").exists() {
         return "go".to_string();
     }
-    
+
     if path.join("requirements.txt").exists() || path.join("pyproject.toml").exists() {
         return "python".to_string();
     }
-    
+
     if path.join("README.md").exists() {
         return "markdown".to_string();
     }
-    
+
     "unknown".to_string()
 }
 
 fn calculate_directory_stats(path: &Path) -> Result<(u64, usize), String> {
     let mut total_size = 0;
     let mut files_count = 0;
-    
+
     fn visit_dir(dir: &Path, size: &mut u64, count: &mut usize) -> std::io::Result<()> {
         if dir.is_dir() {
             for entry in fs::read_dir(dir)? {
@@ -178,21 +164,21 @@ fn calculate_directory_stats(path: &Path) -> Result<(u64, usize), String> {
         }
         Ok(())
     }
-    
+
     visit_dir(path, &mut total_size, &mut files_count)
         .map_err(|e| format!("Failed to calculate directory stats: {}", e))?;
-    
+
     Ok((total_size, files_count))
 }
 
 fn format_system_time(time: std::time::SystemTime) -> String {
-    use std::time::UNIX_EPOCH;
     use chrono::{DateTime, Utc};
-    
+    use std::time::UNIX_EPOCH;
+
     let duration = time.duration_since(UNIX_EPOCH).unwrap();
     let datetime = DateTime::<Utc>::from_timestamp(duration.as_secs() as i64, 0)
         .unwrap_or_else(|| DateTime::from_timestamp(0, 0).unwrap());
-    
+
     datetime.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
@@ -204,7 +190,13 @@ fn get_git_status(path: &Path) -> String {
     }
 
     let output = Command::new("git")
-        .args(["-C", path.to_str().unwrap_or(""), "status", "--porcelain", "--branch"])
+        .args([
+            "-C",
+            path.to_str().unwrap_or(""),
+            "status",
+            "--porcelain",
+            "--branch",
+        ])
         .output();
 
     if let Ok(out) = output {
@@ -252,7 +244,8 @@ fn load_starred_projects() -> Result<HashSet<String>, String> {
 
 fn save_starred_projects(set: &HashSet<String>) -> Result<(), String> {
     let file = starred_file_path()?;
-    let data = serde_json::to_string_pretty(set).map_err(|e| format!("Failed to serialize: {}", e))?;
+    let data =
+        serde_json::to_string_pretty(set).map_err(|e| format!("Failed to serialize: {}", e))?;
     fs::write(file, data).map_err(|e| format!("Failed to write starred file: {}", e))
 }
 
@@ -279,18 +272,26 @@ fn open_project_in_browser(project_path: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn create_project(base_dir: String, category: String, name: String, project_type: String) -> Result<String, String> {
+fn create_project(
+    base_dir: String,
+    category: String,
+    name: String,
+    project_type: String,
+) -> Result<String, String> {
     let base_path = Path::new(&base_dir);
     let category_path = base_path.join(&category);
     let project_path = category_path.join(&name);
-    
+
     if project_path.exists() {
-        return Err(format!("Project '{}' already exists in category '{}'", name, category));
+        return Err(format!(
+            "Project '{}' already exists in category '{}'",
+            name, category
+        ));
     }
-    
+
     fs::create_dir_all(&project_path)
         .map_err(|e| format!("Failed to create project directory: {}", e))?;
-    
+
     // Create basic project structure based on type
     match project_type.as_str() {
         "rust" => {
@@ -298,19 +299,28 @@ fn create_project(base_dir: String, category: String, name: String, project_type
                 .map_err(|e| format!("Failed to create Cargo.toml: {}", e))?;
             fs::create_dir_all(project_path.join("src"))
                 .map_err(|e| format!("Failed to create src directory: {}", e))?;
-            fs::write(project_path.join("src/main.rs"), "fn main() {\n    println!(\"Hello, world!\");\n}")
-                .map_err(|e| format!("Failed to create main.rs: {}", e))?;
-        },
+            fs::write(
+                project_path.join("src/main.rs"),
+                "fn main() {\n    println!(\"Hello, world!\");\n}",
+            )
+            .map_err(|e| format!("Failed to create main.rs: {}", e))?;
+        }
         "node" | "react" | "next" => {
-            fs::write(project_path.join("package.json"), generate_package_json(&name, &project_type))
-                .map_err(|e| format!("Failed to create package.json: {}", e))?;
-        },
+            fs::write(
+                project_path.join("package.json"),
+                generate_package_json(&name, &project_type),
+            )
+            .map_err(|e| format!("Failed to create package.json: {}", e))?;
+        }
         _ => {
-            fs::write(project_path.join("README.md"), format!("# {}\n\nA new {} project.", name, project_type))
-                .map_err(|e| format!("Failed to create README.md: {}", e))?;
+            fs::write(
+                project_path.join("README.md"),
+                format!("# {}\n\nA new {} project.", name, project_type),
+            )
+            .map_err(|e| format!("Failed to create README.md: {}", e))?;
         }
     }
-    
+
     Ok(project_path.to_string_lossy().to_string())
 }
 
@@ -329,14 +339,18 @@ edition = "2021"
 
 fn generate_package_json(name: &str, project_type: &str) -> String {
     let dependencies = match project_type {
-        "react" => r#"    "react": "^18.2.0",
-    "react-dom": "^18.2.0""#,
-        "next" => r#"    "next": "^14.0.0",
+        "react" => {
+            r#"    "react": "^18.2.0",
+    "react-dom": "^18.2.0""#
+        }
+        "next" => {
+            r#"    "next": "^14.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0""#,
+    "react-dom": "^18.2.0""#
+        }
         _ => r#"    "express": "^4.18.0""#,
     };
-    
+
     format!(
         r#"{{
   "name": "{}",
@@ -357,14 +371,14 @@ fn generate_package_json(name: &str, project_type: &str) -> String {
 #[tauri::command]
 fn open_project_in_editor(project_path: String, editor: String) -> Result<(), String> {
     use std::process::Command;
-    
+
     let result = match editor.as_str() {
         "vscode" => Command::new("code").arg(&project_path).spawn(),
         "subl" => Command::new("subl").arg(&project_path).spawn(),
         "vim" => Command::new("vim").arg(&project_path).spawn(),
         _ => return Err(format!("Unsupported editor: {}", editor)),
     };
-    
+
     result.map_err(|e| format!("Failed to open project in {}: {}", editor, e))?;
     Ok(())
 }
@@ -372,22 +386,28 @@ fn open_project_in_editor(project_path: String, editor: String) -> Result<(), St
 #[tauri::command]
 fn open_project_in_terminal(project_path: String) -> Result<(), String> {
     use std::process::Command;
-    
+
     #[cfg(target_os = "windows")]
     let result = Command::new("cmd")
-        .args(&["/C", "start", "cmd", "/K", &format!("cd /D \"{}\"", project_path)])
+        .args(&[
+            "/C",
+            "start",
+            "cmd",
+            "/K",
+            &format!("cd /D \"{}\"", project_path),
+        ])
         .spawn();
-    
+
     #[cfg(target_os = "macos")]
     let result = Command::new("open")
         .args(&["-a", "Terminal", &project_path])
         .spawn();
-    
+
     #[cfg(target_os = "linux")]
     let result = Command::new("gnome-terminal")
         .args(&["--working-directory", &project_path])
         .spawn();
-    
+
     result.map_err(|e| format!("Failed to open terminal: {}", e))?;
     Ok(())
 }
@@ -395,16 +415,16 @@ fn open_project_in_terminal(project_path: String) -> Result<(), String> {
 #[tauri::command]
 fn open_project_in_file_manager(project_path: String) -> Result<(), String> {
     use std::process::Command;
-    
+
     #[cfg(target_os = "windows")]
     let result = Command::new("explorer").arg(&project_path).spawn();
-    
+
     #[cfg(target_os = "macos")]
     let result = Command::new("open").arg(&project_path).spawn();
-    
+
     #[cfg(target_os = "linux")]
     let result = Command::new("xdg-open").arg(&project_path).spawn();
-    
+
     result.map_err(|e| format!("Failed to open file manager: {}", e))?;
     Ok(())
 }
@@ -412,47 +432,67 @@ fn open_project_in_file_manager(project_path: String) -> Result<(), String> {
 #[tauri::command]
 fn get_project_structure(project_path: String) -> Result<serde_json::Value, String> {
     use serde_json::json;
-    
-    fn build_tree(path: &Path, max_depth: usize, current_depth: usize) -> Result<serde_json::Value, String> {
+
+    fn build_tree(
+        path: &Path,
+        max_depth: usize,
+        current_depth: usize,
+    ) -> Result<serde_json::Value, String> {
         if current_depth >= max_depth {
             return Ok(json!({}));
         }
-        
+
         let mut tree = serde_json::Map::new();
-        let entries = fs::read_dir(path)
-            .map_err(|e| format!("Failed to read directory: {}", e))?;
-        
+        let entries = fs::read_dir(path).map_err(|e| format!("Failed to read directory: {}", e))?;
+
         for entry in entries {
             let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
             let path = entry.path();
             let name = path.file_name().unwrap().to_string_lossy().to_string();
-            
+
             // Skip hidden files and common build directories
             if name.starts_with('.') || name == "node_modules" || name == "target" {
                 continue;
             }
-            
+
             if path.is_dir() {
                 tree.insert(name, build_tree(&path, max_depth, current_depth + 1)?);
             } else {
                 tree.insert(name, json!("file"));
             }
         }
-        
+
         Ok(json!(tree))
     }
-    
+
     let path = Path::new(&project_path);
     build_tree(path, 3, 0) // Limit depth to 3 levels
 }
 
+#[tauri::command]
+fn read_workspace_file(
+    app_handle: tauri::AppHandle,
+    relative_path: String,
+) -> Result<String, String> {
+    file_ops::read_file(&app_handle, &relative_path)
+}
+
+#[tauri::command]
+fn write_workspace_file(
+    app_handle: tauri::AppHandle,
+    relative_path: String,
+    contents: String,
+) -> Result<(), String> {
+    file_ops::write_file(&app_handle, &relative_path, &contents)
+}
+
 fn main() {
     tauri::Builder::default()
-        .manage(Mutex::new(AppState::default()))
+        .manage(Mutex::new(app_state::AppState::default()))
         .setup(|app| {
             let base = workspace::ensure_workspace(app)?;
             {
-                let mut state = app.state::<Mutex<AppState>>().lock().unwrap();
+                let mut state = app.state::<Mutex<app_state::AppState>>().lock().unwrap();
                 state.base_dir = base.to_string_lossy().to_string();
             }
             Ok(())
@@ -466,9 +506,10 @@ fn main() {
             open_project_in_file_manager,
             open_project_in_browser,
             toggle_project_star,
-            get_project_structure
+            get_project_structure,
+            read_workspace_file,
+            write_workspace_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
-

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1,5 +1,8 @@
-use std::{fs, path::{Path, PathBuf}};
 use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use tauri::{api::dialog::blocking::FileDialogBuilder, AppHandle};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -58,7 +61,9 @@ pub fn ensure_workspace(app: &AppHandle) -> Result<PathBuf, String> {
     });
 
     create_category_dirs(&base_dir).map_err(|e| e.to_string())?;
-    let cfg = WorkspaceConfig { base_dir: base_dir.clone() };
+    let cfg = WorkspaceConfig {
+        base_dir: base_dir.clone(),
+    };
     cfg.save(app).map_err(|e| e.to_string())?;
     Ok(base_dir)
 }


### PR DESCRIPTION
## Summary
- refactor `AppState` into its own module
- add helper module for reading/writing files within the workspace directory
- expose `read_workspace_file` and `write_workspace_file` Tauri commands
- format workspace util

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: gobject-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b71ea931c8323bf727f239e54adcc