### PR TITLE
Fix project type badges

### DIFF
--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import React from "react";
+import { getProjectTypeLabel } from "@/lib/projectTypes";
 
 export interface ProjectCardProps {
   project: {
@@ -89,7 +90,7 @@ export function ProjectCard({
         </div>
         <div className="flex items-center justify-between text-sm">
           <Badge variant="outline" className="capitalize">
-            {project.project_type}
+            {getProjectTypeLabel(project.project_type)}
           </Badge>
           <GitStatusIndicator status={project.git_status} />
         </div>

--- a/src/components/projects/project-details-sidebar.tsx
+++ b/src/components/projects/project-details-sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Code, Terminal, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { getProjectTypeLabel } from "@/lib/projectTypes";
 
 export interface ProjectDetailsSidebarProps {
   project: {
@@ -56,7 +57,7 @@ export function ProjectDetailsSidebar({
                 <p className="text-xs text-muted-foreground">Type</p>
                 <div className="flex items-center gap-2">
                   <ProjectTypeIcon type={project.project_type} />
-                  <span className="text-sm font-medium">{project.project_type}</span>
+                  <span className="text-sm font-medium">{getProjectTypeLabel(project.project_type)}</span>
                 </div>
               </div>
               <div>

--- a/src/lib/projectTypes.ts
+++ b/src/lib/projectTypes.ts
@@ -1,0 +1,16 @@
+export const PROJECT_TYPE_LABELS: Record<string, string> = {
+  rust: 'Rust',
+  tauri: 'Tauri App',
+  react: 'React App',
+  next: 'Next.js App',
+  node: 'Node.js App',
+  python: 'Python App',
+  go: 'Go App',
+  electron: 'Electron App',
+  markdown: 'Markdown',
+  unknown: 'Unknown',
+};
+
+export function getProjectTypeLabel(type: string): string {
+  return PROJECT_TYPE_LABELS[type] || type;
+}


### PR DESCRIPTION
## Summary
- label project cards and detail view with readable project type names

## Testing
- `pnpm build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d8f0c32d08323a739cd6ef28f8a97