### PR TITLE
Fix project structure sorting

### DIFF
--- a/src/components/projects/project-structure-view.tsx
+++ b/src/components/projects/project-structure-view.tsx
@@ -74,9 +74,17 @@ export function ProjectStructureView({ project, structure }: ProjectStructureVie
   const renderStructure = (obj: any, path = "", level = 0): React.ReactNode => {
     if (!obj || typeof obj !== "object") return null
 
-    return Object.entries(obj)
+    const entries = Object.entries(obj)
       .filter(([key]) => showHidden || !isHidden(key))
-      .map(([key, value]) => {
+      .sort(([aKey, aValue], [bKey, bValue]) => {
+        const aIsFolder = aValue !== "file" && typeof aValue === "object"
+        const bIsFolder = bValue !== "file" && typeof bValue === "object"
+        if (aIsFolder && !bIsFolder) return -1
+        if (!aIsFolder && bIsFolder) return 1
+        return aKey.localeCompare(bKey)
+      })
+
+    return entries.map(([key, value]) => {
         const currentPath = path ? `${path}/${key}` : key
         const isFolder = value !== "file" && typeof value === "object"
         const isExpanded = expandedPaths[currentPath]


### PR DESCRIPTION
## Summary
- sort directories above files in project tree UI
- ensure backend tree builder sorts entries consistently

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `cargo check` *(fails: `gio-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d9ded61a483238b82b568cefc3dad